### PR TITLE
Added .lower on line 65 to make alphabetical sort work with caps

### DIFF
--- a/todo.py
+++ b/todo.py
@@ -62,7 +62,7 @@ class TodoList:
             for idx, task in enumerate(self.tasks, start=1):
                 item = (idx, task)
                 sorted_tasks.append(item)
-            sorted_tasks = sorted(sorted_tasks, key=lambda x: x[1] if isinstance(x, str) else x[1][0])
+            sorted_tasks = sorted(sorted_tasks, key=lambda x: x[1][0].lower() if isinstance(x[1], tuple) else x[1].lower())
             for idx, task in sorted_tasks:
                 if isinstance(task, tuple):  # Task with due date
                     task_name, due_date = task


### PR DESCRIPTION
This fixes the issue with alphabetical sort, using .lower when comparing, all words are compared as lowercase now, so the list will compare correctly no matter if caps are in the word anywhere