### PR TITLE
Testing: added test file for print_menu in todo.py

### DIFF
--- a/test_print_menu.py
+++ b/test_print_menu.py
@@ -42,7 +42,8 @@ def numbered_tasks():
 
 @fixture
 def entire_menu():
-    return f'\n{'\n'.join(menu_tasks_numbered)}\n'
+    inner = '\n'.join(menu_tasks_numbered)
+    return f'\n{inner}\n'
 
 
 

--- a/test_print_menu.py
+++ b/test_print_menu.py
@@ -1,0 +1,86 @@
+from todo import print_menu
+from pytest import fixture
+
+
+
+## Prep
+menu_tasks_naked = [
+    "To-Do List CLI App",
+    "Add task",
+    "List tasks ordered numerically",
+    "List tasks ordered alphabetically",
+    "Delete task",
+    "Add/Update a due date to a task",
+    "Add/Update a tag to a task",
+    "Delete all tasks",
+    "Edit task description",
+    "Show total number of tasks",
+    "Delete a due date to a task",
+    "Delegate task to someone else",
+    "Mark Task Complete",
+    "Quit",
+]
+
+menu_tasks_numbered = ["To-Do List CLI App"]
+for i in range(1, len(menu_tasks_naked)):
+    menu_tasks_numbered.append(f"{i}. {menu_tasks_naked[i]}")
+
+
+
+## Fixtures
+@fixture
+def tasks_count():
+    return len(menu_tasks_naked)
+
+@fixture
+def naked_tasks():
+    return menu_tasks_naked
+
+@fixture
+def numbered_tasks():
+    return menu_tasks_numbered
+
+@fixture
+def entire_menu():
+    return f'\n{'\n'.join(menu_tasks_numbered)}\n'
+
+
+
+## Functional Tests (Basic Cases)
+def test_numbers_only(tasks_count, capfd):
+    print_menu()
+
+    out, err = capfd.readouterr()
+
+    for i in range(1,tasks_count):
+        assert str(i) in out, f'Missing Task number {i}, incorrectly updated/shifted list of tasks?'
+
+    assert str(tasks_count) not in out, f"New Task No.{tasks_count}, update test_print_menu accordingly"
+    assert tasks_count == len(out.strip().split('\n')), f"Unexpected number of lines, perhaps a new tasks or multi-line task?"
+
+def test_naked_tasks(naked_tasks, capfd):
+    print_menu()
+
+    out, err = capfd.readouterr()
+
+    for item in naked_tasks:
+        assert item in out
+
+def test_numbered_tasks(numbered_tasks, capfd):
+    print_menu()
+
+    out, err = capfd.readouterr()
+
+    for item in numbered_tasks:
+        assert item in out
+
+
+
+## Functional Tests (Edge Cases)
+def test_entire_menu(entire_menu, capfd):
+    print_menu()
+    
+    out, err = capfd.readouterr()
+    
+    assert entire_menu == out
+    assert "" == err


### PR DESCRIPTION
Added test file to check whether the print_menu() method in todo.py prints the correct menu.

## Prep
- List of tasks (without numbering) is contained in menu_tasks_naked (makes it easier to update list)
- List of tasks (WITH numbering) is contained in menu_tasks_numbered (compiled from menu_tasks_naked)

## Fixtures
- tasks_count returns the number of tasks +1 (or just the number of lines)
- naked_tasks returns menu_tasks_naked
- numbered_tasks returns menu_tasks_numbered
- entire_menu returns the entirety of the string printed by print_menu() including the '\n' at the edges

## Functional Tests (Basic Cases)
- test_numbers_only checks whether every task number (just the number) is printed
- test_naked_tasks checks whether every task (without the preceding numbering) is printed
- test_numbered_tasks checks whether every task (WITH the preceding numbering) is printed

## Functional Tests (Edge Cases)
- test_entire_menu checks if the print_menu is EXACTLY as its supposed to be without changes. Any changes in print_menu() that tweak the output in anyway will be detected by this final test even if an error bypasses all the other tests



Unless adding new tests, the only changes that need be made to this test file when updating the print_menu() method would be to modify the menu_tasks_naked list at the start. Which does wonders for convenience.